### PR TITLE
CHA-11 | cd: add GitHub Actions workflow for production deployment

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,30 @@
+name: deploy-prod
+on:
+  workflow_run:
+    workflows: ["Build & Push Docker Image"]     # must match the name: of docker.yml
+    types: [completed]
+
+concurrency:
+  group: cd-prod
+  cancel-in-progress: true
+
+jobs:
+  set-image-tag:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # checkout the same commit ref of the triggering run
+          ref: ${{ github.event.workflow_run.head_branch }}
+
+      - name: Update prod overlay image tag
+        working-directory: k8s/overlays/prod
+        run: |
+          kustomize edit set image docker.io/champoi/champcaptures=docker.io/champoi/champcaptures:${{ github.event.workflow_run.head_sha }}
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+          git commit -am "deploy(prod): ${{ github.event.workflow_run.head_sha }}" || echo "No changes"
+          git push


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating production deployments. The workflow is triggered when the "Build & Push Docker Image" workflow completes successfully, and it updates the Kubernetes production overlay to use the latest Docker image. The most important changes are:

**Deployment Automation:**

* Added a new workflow file `deploy-prod.yml` that automates production deployments by updating the image tag in the Kubernetes prod overlay when the Docker image build workflow completes.
* Ensured the workflow only runs if the Docker image build workflow finishes successfully.

**Concurrency and Permissions:**

* Configured concurrency to prevent overlapping deployments and set permissions for writing repository contents.

**Image Tag Update:**

* Uses `kustomize edit set image` to update the Docker image tag in `k8s/overlays/prod` to match the latest commit SHA from the triggering workflow.
* Commits and pushes the updated overlay configuration back to the repository, ensuring the deployment reflects the latest image.