### PR TITLE
CHA-16 | feat(kustomize): update base and prod overlay for champcaptures rollout

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,10 +1,10 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: champcaptures
-spec:
-  selector: { app: champcaptures }
-  ports:
-    - name: http
-      port: 80
-      targetPort: 8080
+# k8s/base/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+labels:               # ← replace commonLabels with labels
+  - pairs:
+      app: champcaptures
+
+resources:
+  - service.yaml

--- a/k8s/base/service.yaml
+++ b/k8s/base/service.yaml
@@ -1,4 +1,13 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: champcaptures
+  labels:
+    app: champcaptures
+spec:
+  type: ClusterIP
+  selector:
+    app: champcaptures          # <-- must match rollout.spec.template.metadata.labels
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: web
+
+resources:
+  - ../../base
+  - rollout.yaml

--- a/k8s/overlays/prod/rollout.yaml
+++ b/k8s/overlays/prod/rollout.yaml
@@ -5,6 +5,8 @@ metadata:
   labels: { app: champcaptures }
 spec:
   replicas: 3
+  revisionHistoryLimit: 3
+  progressDeadlineSeconds: 600
   selector:
     matchLabels: { app: champcaptures }
   template:
@@ -20,7 +22,7 @@ spec:
           image: docker.io/champoi/champcaptures:latest
           ports: [{ containerPort: 8080 }]
           readinessProbe:
-            httpGet: { path: /healthz, port: 8080 }
+            httpGet: { path: /healthz, port: 8080 }   # ensure /healthz exists in the container
             initialDelaySeconds: 5
           livenessProbe:
             httpGet: { path: /healthz, port: 8080 }


### PR DESCRIPTION
https://linear.app/champoi/issue/CHA-16/refine-kustomize-base-and-prod-overlay-for-champcaptures-rollout

This pull request restructures the Kubernetes manifests to follow best practices by separating base and overlay configurations, introduces a production overlay, and improves deployment reliability and maintainability for the `champcaptures` service. The most important changes are grouped below:

**Kustomize Structure and Base Manifest Updates**
* Refactored `k8s/base/kustomization.yaml` to use the correct Kustomize API and kind, moved the Service definition into a separate `service.yaml`, and added labels for resource organization.
* Created `k8s/base/service.yaml` with a proper Kubernetes Service definition (`ClusterIP` type, label selectors, and port mappings), replacing the previous misplaced Kustomization manifest.

**Production Overlay Introduction**
* Added `k8s/overlays/prod/kustomization.yaml` to define a production overlay, specifying the `web` namespace and including both the base resources and a rollout manifest for deployment management.

**Deployment Configuration Improvements**
* Updated `k8s/overlays/prod/rollout.yaml` to set `revisionHistoryLimit` and `progressDeadlineSeconds` for better rollout control and reliability.
* Ensured that health probes in the rollout reference the `/healthz` endpoint, clarifying that this path must exist in the container for readiness and liveness checks.