### PR TITLE
CHA-21 | cd: install kustomize in deploy-prod workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -13,12 +13,19 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           # checkout the same commit ref of the triggering run
+          fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_branch }}
+
+      - name: Setup kustomize
+        uses: imranismail/setup-kustomize@v3
+        with:
+          kustomize-version: '5.4.1'
 
       - name: Update prod overlay image tag
         working-directory: k8s/overlays/prod
@@ -26,5 +33,19 @@ jobs:
           kustomize edit set image docker.io/champoi/champcaptures=docker.io/champoi/champcaptures:${{ github.event.workflow_run.head_sha }}
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"
-          git commit -am "deploy(prod): ${{ github.event.workflow_run.head_sha }}" || echo "No changes"
-          git push
+
+      - name: Create Pull Request for prod deploy
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "deploy(prod): ${{ github.event.workflow_run.head_sha }}"
+          title: "deploy(prod): ${{ github.event.workflow_run.head_sha }}"
+          body: |
+            Promote image to prod
+            Triggered by Build & Push Docker Image run ${{ github.event.workflow_run.id }}.
+          branch: "ci/deploy-prod-${{ github.run_id }}"
+          base: ${{ github.event.workflow_run.head_branch }}
+          add-paths: |
+            k8s/overlays/prod/kustomization.yaml
+          labels: |
+            cd
+            prod


### PR DESCRIPTION
This pull request updates the production deployment workflow to use a pull request-based deployment process and improves automation and traceability. The key changes are grouped below:

**Deployment workflow improvements:**

* The workflow now creates a pull request to promote the new image to production, replacing the previous direct commit and push approach. This uses the `peter-evans/create-pull-request` action and includes commit message, PR title, body, branch naming, and labels for better traceability. (`.github/workflows/deploy-prod.yml`)
* The workflow step permissions have been updated to include `pull-requests: write`, allowing creation of PRs during deployment. (`.github/workflows/deploy-prod.yml`)

**Tooling and configuration enhancements:**

* The workflow now sets up `kustomize` using the `imranismail/setup-kustomize` action, ensuring the required version is available for editing Kubernetes manifests. (`.github/workflows/deploy-prod.yml`)
* The `fetch-depth: 0` option was added to the checkout step, ensuring the full git history is available for PR creation and branch management. (`.github/workflows/deploy-prod.yml`)