### PR TITLE
CHA-22 |  fix(kustomize): resolve patch error in prod overlay for Gremlin service

### DIFF
--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -6,5 +6,6 @@ namespace: web
 resources:
   - ../../base
   - rollout.yaml
-patches:
-  - path: patch-gremlin-serviceid.yaml
+
+patchesStrategicMerge:
+  - patch-gremlin-serviceid.yaml

--- a/k8s/overlays/prod/patch-gremlin-serviceid.yaml
+++ b/k8s/overlays/prod/patch-gremlin-serviceid.yaml
@@ -2,7 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
   name: champcaptures
-  namespace: web
 spec:
   template:
     metadata:


### PR DESCRIPTION
This pull request updates Kubernetes configuration files in the production overlay to improve patch management and resource definitions. The main changes involve switching to a more robust patching strategy and cleaning up resource metadata.

**Kubernetes patching improvements:**

* Switched from the deprecated `patches` field to `patchesStrategicMerge` in `k8s/overlays/prod/kustomization.yaml` for more reliable and maintainable patch application.

**Resource metadata cleanup:**

* Removed the `namespace: web` field from the metadata in `k8s/overlays/prod/patch-gremlin-serviceid.yaml` to avoid redundancy, since the namespace is already set at a higher level.