### PR TITLE
CHA-23 | fix(gremlin): link champcaptures service and add prod overlay patches

### DIFF
--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - rollout.yaml
 patchesStrategicMerge:
   - patch-gremlin-serviceid.yaml
+  - patch-gremlin-rollout-metadata.yaml
+  - patch-gremlin-service-annotations.yaml
 images:
   - name: docker.io/champoi/champcaptures
     newTag: 22b1cf0b5e9dd258b81f198e881e1f2e9c3c5494

--- a/k8s/overlays/prod/patch-gremlin-rollout-metadata.yaml
+++ b/k8s/overlays/prod/patch-gremlin-rollout-metadata.yaml
@@ -1,0 +1,9 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: champcaptures
+  annotations:
+    gremlin.com/service-id: champcaptures
+    gremlin.com/tags: environment:prod,team:platform
+    # Optional only if you manage multiple Gremlin teams:
+    # gremlin.com/team-id: <your-team-id>

--- a/k8s/overlays/prod/patch-gremlin-service-annotations.yaml
+++ b/k8s/overlays/prod/patch-gremlin-service-annotations.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: champcaptures
+  annotations:
+    gremlin.com/service-id: champcaptures
+    gremlin.com/tags: environment:prod,team:platform

--- a/k8s/overlays/prod/patch-gremlin-serviceid.yaml
+++ b/k8s/overlays/prod/patch-gremlin-serviceid.yaml
@@ -7,4 +7,4 @@ spec:
     metadata:
       annotations:
         gremlin.com/service-id: champcaptures
-        gremlin.com/tags: env=prod,team=platform
+        gremlin.com/tags: environment:prod,team:platform


### PR DESCRIPTION
This pull request updates the Kubernetes production overlay to standardize Gremlin annotations and improve metadata for both the `Rollout` and `Service` resources. The changes ensure consistent tagging and better integration with Gremlin for chaos engineering.

**Gremlin integration and annotation improvements:**

* Standardized the `gremlin.com/tags` annotation format to `environment:prod,team:platform` in `patch-gremlin-serviceid.yaml` for consistency across resources.
* Added new strategic merge patches for Gremlin annotations: `patch-gremlin-rollout-metadata.yaml` and `patch-gremlin-service-annotations.yaml` to the production overlay configuration in `kustomization.yaml`.
* Introduced `patch-gremlin-rollout-metadata.yaml` to annotate the `Rollout` resource with Gremlin service ID and tags, and optionally a team ID.
* Introduced `patch-gremlin-service-annotations.yaml` to annotate the `Service` resource with Gremlin service ID and tags.